### PR TITLE
v1.2.3 Fix duels being accepted while dead.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.realized</groupId>
     <artifactId>duels</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <name>Duels</name>
     <description>Everything you need for duels.</description>
 

--- a/src/main/java/me/realized/duels/commands/duel/subcommands/AcceptCommand.java
+++ b/src/main/java/me/realized/duels/commands/duel/subcommands/AcceptCommand.java
@@ -62,6 +62,11 @@ public class AcceptCommand extends SubCommand {
             return;
         }
 
+        if(target.isDead()) {
+            pm(sender, "&cThe player you tried to duel is dead - Try again when they respawn.");
+            return;
+        }
+
         Request request = requestManager.getRequestFrom(player, target);
         requestManager.removeRequestFrom(player, target);
         duelManager.startMatch(player, target, request);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Duels
 main: me.realized.duels.Core
-version: 1.2.2
+version: 1.2.3
 author: Realized
 description: An ultimate solution to server owners wanting to create a duel system.
 softdepend: [WorldGuard, Multiverse-Core, Essentials]


### PR DESCRIPTION
There is a bug in the plugin where if a player is dead after having sent a duel request to another player and that player accepts it, the person will then be able to respawn with the duel items outside of the duel arena.

This fixes this bug by not allowing people to accept duel requests if the target of the request is currently dead.