### PR TITLE
reset exhaustion and saturation when resetting player

### DIFF
--- a/duels-plugin/src/main/java/me/realized/duels/util/PlayerUtil.java
+++ b/duels-plugin/src/main/java/me/realized/duels/util/PlayerUtil.java
@@ -11,6 +11,8 @@ import org.bukkit.inventory.ItemStack;
 public final class PlayerUtil {
 
     private static final double DEFAULT_MAX_HEALTH = 20.0D;
+    private static final float DEFAULT_EXHAUSTION = 0.0F;
+    private static final float DEFAULT_SATURATION = 5.0F;
     private static final int DEFAULT_MAX_FOOD_LEVEL = 20;
 
     public static double getMaxHealth(final Player player) {
@@ -35,6 +37,8 @@ public final class PlayerUtil {
         player.setFireTicks(0);
         player.getActivePotionEffects().forEach(effect -> player.removePotionEffect(effect.getType()));
         setMaxHealth(player);
+        player.setExhaustion(DEFAULT_EXHAUSTION);
+        player.setSaturation(DEFAULT_SATURATION);
         player.setFoodLevel(DEFAULT_MAX_FOOD_LEVEL);
         player.setItemOnCursor(null);
 


### PR DESCRIPTION
When resetting a player's food level, his exhaustion and saturation are leaved unchanged, which leads to an unfairness because the two values determine how fast the hunger level depletes. This pull request makes the resetting method handles them properly.